### PR TITLE
fixed import statement for Xcode 8.1

### DIFF
--- a/MTStringAttributes/MTStringParser.m
+++ b/MTStringAttributes/MTStringParser.m
@@ -7,7 +7,7 @@
 //
 
 #import "MTStringParser.h"
-#import <SLSMarkupParser.h>
+#import "SLSMarkupParser.h"
 
 
 @interface MTStringParser ()


### PR DESCRIPTION
Unable to compile with `#import "SLSMarkupParser.h”` in latest Xcode

Thank you for the package 